### PR TITLE
Prevent duplicate files being added to a holding

### DIFF
--- a/nlds/rabbit/consumer.py
+++ b/nlds/rabbit/consumer.py
@@ -69,10 +69,11 @@ class State(Enum):
     ROUTING = 0
     SPLITTING = 1
     INDEXING = 2
-    TRANSFER_PUTTING = 3
-    CATALOG_PUTTING = 4
-    CATALOG_GETTING = 5
-    TRANSFER_GETTING = 6
+    CATALOG_PUTTING = 3
+    TRANSFER_PUTTING = 4
+    CATALOG_ROLLBACK = 5
+    CATALOG_GETTING = 6
+    TRANSFER_GETTING = 7
     COMPLETE = 8
     FAILED = 9
 
@@ -86,7 +87,7 @@ class State(Enum):
 
     @classmethod
     def get_final_states(cls):
-        return cls.TRANSFER_GETTING, cls.CATALOG_PUTTING, cls.FAILED
+        return cls.TRANSFER_GETTING, cls.TRANSFER_PUTTING, cls.FAILED
 
 class RabbitMQConsumer(ABC, RabbitMQPublisher):
     DEFAULT_QUEUE_NAME = "test_q"

--- a/nlds/rabbit/publisher.py
+++ b/nlds/rabbit/publisher.py
@@ -54,6 +54,7 @@ class RabbitMQPublisher():
     RK_CATALOG = "catalog"
     RK_CATALOG_PUT = "catalog-put"
     RK_CATALOG_GET = "catalog-get"
+    RK_CATALOG_DEL = "catalog-del"
     RK_MONITOR = "monitor"
     RK_MONITOR_PUT = "monitor-put"
     RK_MONITOR_GET = "monitor-get"

--- a/nlds_processors/catalog/catalog_models.py
+++ b/nlds_processors/catalog/catalog_models.py
@@ -23,9 +23,9 @@ class Holding(CatalogBase):
     # group who owns this holding
     group = Column(String, nullable=False)
     # relationship for tags (One to many)
-    tags = relationship("Tag", backref="holding", cascade="delete")
+    tags = relationship("Tag", backref="holding", cascade="delete, delete-orphan")
     # relationship for transactions (One to many)
-    transactions = relationship("Transaction")
+    transactions = relationship("Transaction", cascade="delete, delete-orphan")
     # label must be unique per user
     __table_args__ = (UniqueConstraint('label', 'user'),)
 
@@ -41,7 +41,7 @@ class Transaction(CatalogBase):
     # date and time of ingest / adding to catalogue
     ingest_time = Column(DateTime)
     # relationship for files (One to many)
-    files = relationship("File")
+    files = relationship("File", cascade="delete, delete-orphan")
     # holding id as ForeignKey "Parent"
     holding_id = Column(Integer, ForeignKey("holding.id"), 
                         index=True, nullable=False)
@@ -83,9 +83,9 @@ class File(CatalogBase):
     file_permissions = Column(Integer)
 
     # relationship for location (one to many)
-    location = relationship("Location")
+    location = relationship("Location", cascade="delete, delete-orphan")
     # relationship for checksum (one to one)
-    checksum = relationship("Checksum")
+    checksum = relationship("Checksum", cascade="delete, delete-orphan")
 
 
 class Storage(enum.Enum):

--- a/nlds_processors/monitor/monitor_models.py
+++ b/nlds_processors/monitor/monitor_models.py
@@ -52,7 +52,7 @@ class SubRecord(MonitorBase):
 
     def has_finished(self):
         """Convenience method for checking whether a given SubRecord is in a 
-        'final' state, i.e. is no longer going ot change and the transaction can 
+        'final' state, i.e. is no longer going to change and the transaction can 
         therefore be marked as COMPLETE.
 
         Checks whether all states have gotten to the final stage of a workflow 

--- a/nlds_processors/transferers/base_transfer.py
+++ b/nlds_processors/transferers/base_transfer.py
@@ -35,7 +35,6 @@ class BaseTransferConsumer(StattingConsumer, ABC):
         _REQUIRE_SECURE: True,
         _CHECK_PERMISSIONS: True,
         _PRINT_TRACEBACKS: False,
-        _REMOVE_ROOT_SLASH: True,
         _MAX_RETRIES: 5,
         _FILELIST_MAX_LENGTH: 1000,
         RMQP.RETRY_DELAYS: RMQP.DEFAULT_RETRY_DELAYS,
@@ -56,8 +55,6 @@ class BaseTransferConsumer(StattingConsumer, ABC):
             self._MAX_RETRIES)
         self.filelist_max_len = self.load_config_value(
             self._FILELIST_MAX_LENGTH)
-        self.remove_root_slash_fl = self.load_config_value(
-            self._REMOVE_ROOT_SLASH)
         self.retry_delays = self.load_config_value(
             self.RETRY_DELAYS)
 

--- a/nlds_processors/transferers/get_transfer.py
+++ b/nlds_processors/transferers/get_transfer.py
@@ -96,10 +96,6 @@ class GetTransferConsumer(BaseTransferConsumer):
             self.log(f"Attempting to get file {object_name} from {bucket_name}", 
                      self.RK_LOG_DEBUG)
 
-            if (self.remove_root_slash_fl and 
-                    object_name[0] == "/"):
-                object_name = object_name[1:]
-
             # Decide whether to prepend target path or download directly to it.
             if not target:
                 # In the case of no given target, we just download the files 

--- a/nlds_processors/transferers/put_transfer.py
+++ b/nlds_processors/transferers/put_transfer.py
@@ -94,7 +94,7 @@ class PutTransferConsumer(BaseTransferConsumer):
                 self.log(f"Successfully uploaded {path_details.original_path}", 
                         self.RK_LOG_DEBUG)
                 self.append_and_send(path_details, rk_complete, body_json, 
-                                    list_type=FilelistType.transferred)
+                                     list_type=FilelistType.transferred)
             except HTTPError as e: 
                 reason = (f"Error uploading {path_details.path} to object "
                           f"store: {e}.")

--- a/nlds_processors/transferers/put_transfer.py
+++ b/nlds_processors/transferers/put_transfer.py
@@ -84,8 +84,6 @@ class PutTransferConsumer(BaseTransferConsumer):
             # object-name at all
             path_details.object_name = path_details.original_path
             try:
-                if path_details.original_path == "/Users/jack.leland/coding/projects/nlds_repos/client-tests/test_dir_1/test_texts/test_file_7.txt":
-                    raise HTTPError
                 result = client.fput_object(
                     bucket_name, 
                     path_details.object_name, 

--- a/test_run/start_test_run.sh
+++ b/test_run/start_test_run.sh
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+if [[ ! -d ~/nlds_log ]]
+then
+    mkdir ~/nlds_log
+fi
+
+source $HOME/python-venvs/nlds-venv/bin/activate
+# start a named screen session
+screen -S nlds -c test_run.rc 

--- a/test_run/stop_test_run.sh
+++ b/test_run/stop_test_run.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+screen -d nlds
+screen -r nlds -X quit


### PR DESCRIPTION
Overhaul of NLDS put workflow to ensure that duplicate files cannot be added to a given holding. This required reordering the `CATALOG_PUT` to before the `TRANSFER_PUT` and deleting any files that did not transfer properly with a `_catalog_del` function in the catalog. The check for duplicates is now done at the catalog_put stage and will fail/retry at that point. 

Things to be aware of:
- Working on the transfer_put has reminded me that we need transaction-level retries/failures as it was difficult to fail an individual file at the transfer step. 
- The `_catalog_del` function is intended to double for use in the DEL functionality when we get round to implementing it (which we could do now, specifically for files). It doesn't, as of this commit, check for empty transactions as that is not part of the scope of duplicate handling, but it would not be hard to add this in if we wanted to. 
- The `_catalog_del` function also does have a state associated with it (CATALOG_ROLLBACK) but this is not visible to users now as the job will already have failed at that point. **It is an open question whether we want to display that information to users or not**, and if so we will need to figure out how to decided the state produced at the end of the `_catalog_del`.
- The `REMOVE_ROOT_SLASH` functionality has been removed so that the object name can be known with certainty before the object is created at transfer time. This is fine for now as the object name is always equivalent to the original path (do we still need to store both?) but if this changes in the future we may need an additional stage in the workflow which updates the object name post-transfer.  