### PR TITLE
Fix for modify holding attribute error

### DIFF
--- a/nlds_processors/catalog/catalog.py
+++ b/nlds_processors/catalog/catalog.py
@@ -157,6 +157,11 @@ class Catalog(DBMixin):
                        del_tags: dict=None) -> Holding:
         """Find a holding and modify the information in it"""
         assert(self.session != None)
+        if not isinstance(holding, Holding):
+            raise CatalogError(
+                f"Cannot modify holding, it does not appear to be a valid "
+                f"Holding ({holding})." 
+            )
         # change the label if a new_label supplied
         if new_label:
             try:


### PR DESCRIPTION
This is to fix the failing test on `modify_holding()`, which is due to the lack of input checking done on the holding passed into the function. This could just as easily be fixed by wrapping everything in a try-catch to catch an AttributeError later in the function, but I think this pre-empts that and makes it a bit neater. Lemme know your thoughts. 