### PR TITLE
two bugfixes - see full description

### DIFF
--- a/nlds_processors/catalog/catalog_worker.py
+++ b/nlds_processors/catalog/catalog_worker.py
@@ -1613,7 +1613,7 @@ class CatalogConsumer(RMQC):
                     "Holding not found: holding_id or label or tag(s) not specified."
                 )
             holdings = self.catalog.get_holding(
-                user, group, holding_label, holding_id, tag=tag
+                user, group, label=holding_label, holding_id=holding_id, tag=tag
             )
             ret_list = []
             for holding in holdings:


### PR DESCRIPTION
Two bugfixes.

- One fixes a problem that `nlds meta -i ...` doesn't work properly (the call doesn't allow for the `groupall` positional arg, so arguments are passed to the wrong parameter in the function). This is line 1616 and should be straightforward to review.

- The other fixes the fact that (once the above is fixed) the new_meta is reported incorrectly: it is just a copy of the old_meta, because the catalog has not yet been saved. This might require more careful review, although it works when I test it manually. (Maybe we also need a test for this.)