### PR TITLE
Not sure, but I think this avoids the RETURNING clause!

### DIFF
--- a/nlds_processors/catalog/catalog.py
+++ b/nlds_processors/catalog/catalog.py
@@ -607,7 +607,7 @@ class Catalog(DBMixin):
                 user=user,
                 group=group,
                 file_permissions=file_permissions,
-            )
+            ).inline()
             self.session.execute(statement)
         except (IntegrityError, KeyError):
             raise CatalogError(


### PR DESCRIPTION
Check this, it may not commit to the DB. But IIRC session.add _might_ as a RETURNING statement by default but session.execute won't unless told to.